### PR TITLE
[Docs] Make Requirement Document Link Use target="_blank" via HTML

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,6 +100,7 @@ amour-editorials/
 ## Requirement Document
 
 [📎 Click here to view the Requirement Document (Google Drive)](https://drive.google.com/drive/folders/1UKhRycAPGKAMnXEQuGMF5JSSEaz0_awR?usp=sharing)
+📎 <a href="https://drive.google.com/drive/folders/1UKhRycAPGKAMnXEQuGMF5JSSEaz0_awR?usp=sharing" target="_blank" rel="noopener noreferrer">Click here to view the Requirement Document</a>
 
 Includes detailed scope, objectives, features, UI structure, and technical expectations of the project — verified by the project managers.
 

--- a/README.md
+++ b/README.md
@@ -99,7 +99,6 @@ amour-editorials/
 
 ## Requirement Document
 
-[📎 Click here to view the Requirement Document (Google Drive)](https://drive.google.com/drive/folders/1UKhRycAPGKAMnXEQuGMF5JSSEaz0_awR?usp=sharing)
 📎 <a href="https://drive.google.com/drive/folders/1UKhRycAPGKAMnXEQuGMF5JSSEaz0_awR?usp=sharing" target="_blank" rel="noopener noreferrer">Click here to view the Requirement Document</a>
 
 Includes detailed scope, objectives, features, UI structure, and technical expectations of the project — verified by the project managers.


### PR DESCRIPTION
## What I Did
Replaced the Markdown link for the Requirement Document with an HTML anchor tag using `target="_blank"` to improve UX by opening it in a new tab.

## Why
Markdown links on GitHub do not support `target="_blank"`, but HTML links do — although GitHub ignores the `target="_blank"` attribute in rendered views. Still, this is semantically correct and works in other markdown renderers.

## Notes
This doesn't change behavior on GitHub but preserves intent and improves UX in environments that respect the attribute.

## Closes
Closes #36 