### PR TITLE
added clickable MIT license link in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -223,6 +223,8 @@ _Your contributions will be reviewed and appreciated! Let’s build something im
 | Testimonials        | ![Testimonials](images/testimonials.png) |
 | Responsive View     | ![Mobile View](images/mobile-view.png)   |
 
+## License  
+This project is licensed under the [MIT License](LICENSE).
 
 <p align="center">
   <a href="#top" style="font-size: 18px; padding: 8px 16px; display: inline-block; border: 1px solid #ccc; border-radius: 6px; text-decoration: none;">


### PR DESCRIPTION
I have added the license in the readme file you can check and accept the pr request.
<img width="1431" height="518" alt="Screenshot 2025-07-31 093638" src="https://github.com/user-attachments/assets/35e9d33c-72fa-4d59-8706-649333c81b7b" />
<img width="1423" height="463" alt="Screenshot 2025-07-31 093646" src="https://github.com/user-attachments/assets/e6122f44-4ae0-42a5-8ad0-418d134b8198" />
